### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,15 +12,15 @@ FreqPeriodCounter	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-poll KEYWORD2
-synchronize KEYWORD2
-ready KEYWORD2 KEYWORD2
-hertz KEYWORD2 KEYWORD2
-period KEYWORD2
-pulseWidth KEYWORD2
-pulseWidthLow KEYWORD2
-elapsedTime KEYWORD2
-level KEYWORD2
+poll	KEYWORD2
+synchronize	KEYWORD2
+ready	KEYWORD2	KEYWORD2
+hertz	KEYWORD2	KEYWORD2
+period	KEYWORD2
+pulseWidth	KEYWORD2
+pulseWidthLow	KEYWORD2
+elapsedTime	KEYWORD2
+level	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords